### PR TITLE
Update grunt-sass min version to 0.18.0 to fix inker installation on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "grunt-nunjucks": "^0.1.4",
     "grunt-nunjucks-2-html": "^0.2.3",
     "grunt-premailer": "^0.2.11",
-    "grunt-sass": "^0.17.0",
+    "grunt-sass": "^0.18.0",
     "nunjucks": "^1.1.0",
     "grunt-nodemailer": "^0.3.0"
   },


### PR DESCRIPTION
Mini change to be able to install the tool on windows. The fix was done in grunt-sass in version 0.18.0.
